### PR TITLE
Quick workaround to fix unicode variable issue (TIMOB-18770)

### DIFF
--- a/Source/JavaScriptCore/parser/Lexer.cpp
+++ b/Source/JavaScriptCore/parser/Lexer.cpp
@@ -639,7 +639,12 @@ ALWAYS_INLINE bool Lexer<T>::lastTokenWasRestrKeyword() const
 
 static NEVER_INLINE bool isNonLatin1IdentStart(int c)
 {
+#if OS(WINDOWS_PHONE) || OS(WINDOWS)
+    // Every non-latin1 character can be identifier (TODO: Is this always valid?)
+    return true;
+#else
     return category(c) & (Letter_Uppercase | Letter_Lowercase | Letter_Titlecase | Letter_Modifier | Letter_Other);
+#endif
 }
 
 static ALWAYS_INLINE bool isLatin1(LChar)
@@ -664,8 +669,13 @@ static inline bool isIdentStart(UChar c)
 
 static NEVER_INLINE bool isNonLatin1IdentPart(int c)
 {
+#if OS(WINDOWS_PHONE) || OS(WINDOWS)
+    // Every non-latin1 character can be part of identifier (TODO: Is this always valid?)
+    return true;
+#else
     return (category(c) & (Letter_Uppercase | Letter_Lowercase | Letter_Titlecase | Letter_Modifier | Letter_Other
         | Mark_NonSpacing | Mark_SpacingCombining | Number_DecimalDigit | Punctuation_Connector)) || c == 0x200C || c == 0x200D;
+#endif
 }
 
 static ALWAYS_INLINE bool isIdentPart(LChar c)


### PR DESCRIPTION
Workaround to fix [TIMOB-18770](https://jira.appcelerator.org/browse/TIMOB-18770). It treats every "non-latin1" characters be part of identifier. rough implementation but it actually works so far.

Background:

> While trying to apply recent changes around [JavaScriptCore Lexer](https://github.com/WebKit/webkit/commit/2eb5f4de2fb20e7dddaba89da5118e84d71d82c5#diff-0af0b457165c27ee7ef19b92709c2df1) , I found that recent JavaScriptCore is trying to eliminates use of `WTF::Unicode` but instead use ICU directly. The problem here is that our JavaScriptCore for Windows is relying on custom `WTF::Unicode` handler for wchar_t which is built specifically for Windows, which doesn't depend on ICU. That's why we can't merge latest changes around Lexer as it is. So the actual issue now is that, it looks like we actually didn't implement Unicode detection in our custom `WTF::Unicode` handler. See [WTF/wtf/unicode/wchar/UnicodeWchar.cpp](https://github.com/appcelerator/webkit/blob/javascriptcore-wp8.1/Source/WTF/wtf/unicode/wchar/UnicodeWchar.cpp#L33) , we can see some `FIXME: implement` comment there.

```javascript
var φ = 'hello world';

var window = Ti.UI.createWindow({
    backgroundColor: "blue"
});

var label = Ti.UI.createLabel({ text: φ });
window.add(label);
window.open();
```
